### PR TITLE
FA-88: refactor creator dashboard

### DIFF
--- a/DB/connection.ts
+++ b/DB/connection.ts
@@ -1,8 +1,10 @@
+"server-only"
 import mongoose from "mongoose";
 
 const MONGO_URI = process.env.MONGODB_URI as string;
 
 if (!MONGO_URI) {
+    console.log(MONGO_URI)
     throw new Error("⚠️ Error: MONGO_URI environment variable is missing!");
 }
 

--- a/app/(main)/admin/dashboard/components/adminDashboard.tsx
+++ b/app/(main)/admin/dashboard/components/adminDashboard.tsx
@@ -1,4 +1,4 @@
-"use client" 
+"use client"
 import {Tabs, TabsContent} from "@/components/ui/tabs"
 import {
     Card,

--- a/app/(main)/admin/dashboard/components/allStates.tsx
+++ b/app/(main)/admin/dashboard/components/allStates.tsx
@@ -1,4 +1,3 @@
-import { IStateCard } from '@/@types'
 import React from 'react'
 import StateCard from './stateCard'
 interface IProps {

--- a/app/(main)/admin/dashboard/components/charts/usersActivity.tsx
+++ b/app/(main)/admin/dashboard/components/charts/usersActivity.tsx
@@ -8,9 +8,8 @@ import {
     ResponsiveContainer
 } from "recharts";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
-import { IUserData, IUsersActivityData } from "@/@types";
+import { IUsersActivityData } from "@/@types";
 
-  // Sample data
 interface IProps {
     userActivityData: IUsersActivityData[];
 }

--- a/app/(main)/admin/dashboard/components/stateCard.tsx
+++ b/app/(main)/admin/dashboard/components/stateCard.tsx
@@ -1,7 +1,6 @@
-import { IStateCard } from '@/@types'
+import React from 'react'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { Users, ArrowUpRight } from 'lucide-react'
-import React from 'react'
 interface IProps extends IStateCard {} 
 const StateCard = (props: IProps) => {
     const {

--- a/app/(main)/admin/dashboard/page.tsx
+++ b/app/(main)/admin/dashboard/page.tsx
@@ -1,10 +1,5 @@
-import React from 'react';
 import AdminDashboard from './components/adminDashboard';
 import FetchData from "./services/fetchData.service";
-import { connection } from '@/DB/connection';
-import FormModel from '@/DB/models/form.model';
-import responseModel from '@/DB/models/response.model';
-import mongoose from 'mongoose';
 
 const page = async() => {
 

--- a/app/(main)/admin/dashboard/services/fetchData.service.ts
+++ b/app/(main)/admin/dashboard/services/fetchData.service.ts
@@ -1,10 +1,10 @@
 import { 
-            IDashboardForm, 
-            IFormCreationData, 
-            IFormResponseData, 
-            IUserData, 
-            IUsersActivityData 
-        } from "@/@types";
+    IFormTable, 
+    IFormCreationData, 
+    IFormResponseData, 
+    IUserData, 
+    IUsersActivityData 
+} from "@/@types";
 
 class FetchData {
     private baseUrl: string = "http://localhost:3000//api/dashboard";
@@ -89,7 +89,7 @@ class FetchData {
         }    
     }
     
-    async formsData(): Promise<IDashboardForm[]> {
+    async formsData(): Promise<IFormTable[]> {
         try {
             const res = await fetch(`${this.baseUrl}/forms-data`);
             const data = await res.json();
@@ -97,7 +97,7 @@ class FetchData {
                 console.error(data.message);
                 return [];
             }
-            const formsData: IDashboardForm[] = data.formsData;
+            const formsData: IFormTable[] = data.formsData;
             return formsData;
         }
         catch(err) {

--- a/app/(main)/creator/[name]/dashboard/components/allStates.tsx
+++ b/app/(main)/creator/[name]/dashboard/components/allStates.tsx
@@ -1,13 +1,4 @@
-import type { ReactNode } from "react"
 import StateCard from "./stateCard"
-
-
-interface IStateCard {
-  stateTitle: string
-  stateValue: string | number
-  statePercentage: number
-  icon?: ReactNode
-}
 
 interface IProps {
   cards: IStateCard[]

--- a/app/(main)/creator/[name]/dashboard/components/creatorDashboard.tsx
+++ b/app/(main)/creator/[name]/dashboard/components/creatorDashboard.tsx
@@ -1,9 +1,12 @@
 "use client"
-
-import { Tabs, TabsContent } from "@/components/ui/tabs"
-import { Card, CardContent } from "@/components/ui/card"
-import { useContext, useMemo } from "react"
-import { BarChart, PieChart, LayoutDashboard, FileText, Users } from "lucide-react"
+import {Tabs, TabsContent} from "@/components/ui/tabs"
+import {Card, CardContent} from "@/components/ui/card"
+import {useContext} from "react"
+import {
+    LayoutDashboard,
+    FileText,
+    Users
+} from "lucide-react"
 import useCreatorDashboard from "../hooks/useDashboard"
 import DashboardHeader from "./dashboardHeader"
 import AllTabs from "./allTabs"
@@ -11,165 +14,157 @@ import AllCards from "./allStates"
 import AllCharts from "./allCharts"
 import TabHeader from "./tabHeader"
 import SearchBar from "./searchBar"
-import FormsTable from "@/components/forms-table/formsTable"
-import ResponsesTable from "./responsesTable"
+import ResponsesTable from "./responses-table/responsesTable"
 import CreatorFormsTable from "./creatorFormsTable"
-import { ICreatorActivityData, ICreatorFormData, ICreatorResponses, IFormCreationData, IFormResponseData } from "../types"
-import { IFormTable } from "@/@types"
-import { AuthContext } from "@/providers/auth/authProvider"
+import {
+    ICreatorActivityData,
+    ICreatorResponses,
+    IFormCreationData,
+    IFormResponseData
+} from "../types"
+import {IFormTable} from "@/@types"
+import {AuthContext} from "@/providers/auth/authProvider"
 import LoadingPage from "@/components/loadingPage/loadingPage"
 export const dummyForms = [
-  {
-    id: "1",
-    name: "Customer Feedback",
-    creator: "John Doe",
-    responses: 12,
-    createdAt: new Date("2025-04-01T10:00:00Z"),
-  },
-  {
-    id: "2",
-    name: "Survey: UI Preferences",
-    creator: "Jane Smith",
-    responses: 30,
-    createdAt: new Date("2025-04-15T15:20:00Z"),
-  },
-  {
-    id: "3",
-    name: "Bug Report Form",
-    creator: "Alice Johnson",
-    responses: 5,
-    createdAt: new Date("2025-03-28T08:30:00Z"),
-  },
-  {
-    id: "4",
-    name: "Event Registration",
-    creator: "Bob Brown",
-    responses: 89,
-    createdAt: new Date("2025-05-01T12:45:00Z"),
-  },
-  {
-    id: "5",
-    name: "Weekly Feedback",
-    creator: "Charlie Green",
-    responses: 17,
-    createdAt: new Date("2025-04-29T09:00:00Z"),
-  },
+    {
+        id: "1",
+        name: "Customer Feedback",
+        creator: "John Doe",
+        responses: 12,
+        createdAt: new Date("2025-04-01T10:00:00Z")
+    },
+    {
+        id: "2",
+        name: "Survey: UI Preferences",
+        creator: "Jane Smith",
+        responses: 30,
+        createdAt: new Date("2025-04-15T15:20:00Z")
+    },
+    {
+        id: "3",
+        name: "Bug Report Form",
+        creator: "Alice Johnson",
+        responses: 5,
+        createdAt: new Date("2025-03-28T08:30:00Z")
+    },
+    {
+        id: "4",
+        name: "Event Registration",
+        creator: "Bob Brown",
+        responses: 89,
+        createdAt: new Date("2025-05-01T12:45:00Z")
+    }, {
+        id: "5",
+        name: "Weekly Feedback",
+        creator: "Charlie Green",
+        responses: 17,
+        createdAt: new Date("2025-04-29T09:00:00Z")
+    },
 ];
 
 
 interface IProps {
-  formsData: IFormTable[]
-  formCreationData: IFormCreationData[]
-  formResponsesData: IFormResponseData[]
-  creatorActivityData: ICreatorActivityData[]
-  responses: ICreatorResponses[]
+    formsData: IFormTable[]
+    formCreationData: IFormCreationData[]
+    formResponsesData: IFormResponseData[]
+    creatorActivityData: ICreatorActivityData[]
+    responses: ICreatorResponses[]
 }
 
 const CREATOR_TABS = [
-  {
-    value: "overview",
-    label: "Overview",
-    icon: <LayoutDashboard className="h-4 w-4" />,
-  },
-  {
-    value: "forms",
-    label: "My Forms",
-    icon: <FileText className="h-4 w-4" />,
-  },
-  {
-    value: "responses",
-    label: "Responses",
-    icon: <Users className="h-4 w-4" />,
-  },
+    {
+        value: "overview",
+        label: "Overview",
+        icon: <LayoutDashboard className="h-4 w-4"/>
+    }, {
+        value: "forms",
+        label: "My Forms",
+        icon: <FileText className="h-4 w-4"/>
+    }, {
+        value: "responses",
+        label: "Responses",
+        icon: <Users className="h-4 w-4"/>
+    },
 ]
 
-const CreatorDashboard = (props: IProps) => {
-  const { formsData, formCreationData, formResponsesData, creatorActivityData,  responses} = props
-  const {user, isLoading} = useContext(AuthContext)
-  const {
-    filteredForms,
-    filteredResponses,
-    totalForms,
-    totalResponses,
-    searchForms,
-    searchResponses,
-    recentResponses,
-    setSearchForms,
-    setSearchResponses,
-  } = useCreatorDashboard({ formsData,  responses})
+const CreatorDashboard = (props : IProps) => {
+    const {
+        formsData,
+        formCreationData,
+        formResponsesData,
+        creatorActivityData,
+        responses
+    } = props
+    const {user, isLoading} = useContext(AuthContext)
+    const {
+        slicedForms,
+        slicedResponses,
+        stateCardsData,
+        searchForms,
+        searchResponses,
+        recentResponses,
+        setSearchForms,
+        setSearchResponses
+    } = useCreatorDashboard({formsData, responses})
 
 
-  const stateCardsData = useMemo(
-    () => [
-      {
-        stateTitle: "Total Forms",
-        stateValue: totalForms,
-        statePercentage: 10,
-        icon: <FileText className="h-5 w-5 text-purple-500" />,
-      },
-      {
-        stateTitle: "Active Forms",
-        stateValue: 8,
-        statePercentage: 15,
-        icon: <BarChart className="h-5 w-5 text-green-500" />,
-      },
-      {
-        stateTitle: "Total Responses",
-        stateValue: totalResponses,
-        statePercentage: 12,
-        icon: <Users className="h-5 w-5 text-purple-500" />,
-      },
-    ],
-    [totalForms, totalResponses],
-  )
-  if(isLoading) {
-      return (
-        <div className="w-full min-h-screen bg-white px-4 md:px-10 py-8">
-            <LoadingPage/>
+    if (isLoading) {
+        return (
+            <div className="w-full min-h-screen bg-white px-4 md:px-10 py-8">
+                <LoadingPage/>
+            </div>
+        )
+    }
+    return (
+        <div className="min-h-screen bg-gradient-to-br from-purple-50 to-purple-100 pb-20 pt-0 md:pt-0 w-full">
+            <DashboardHeader/>
+            <div className="container mx-auto px-4 py-8">
+                <Tabs defaultValue="overview" className="space-y-6">
+                    <AllTabs tabs={CREATOR_TABS}/>
+
+                    <TabsContent value="overview" className="space-y-6">
+                        <AllCards cards={stateCardsData}/>
+
+                        <AllCharts formResponsesData={formResponsesData}
+                            formCreationData={formCreationData}
+                            creatorActivityData={creatorActivityData}
+                            recentResponses={recentResponses}/>
+                    </TabsContent>
+
+                    <TabsContent value="forms" className="space-y-6">
+                        <Card>
+                            <TabHeader title="My Forms" description="View and manage all your created forms"/>
+                            <CardContent>
+                                <SearchBar placeholder="Search forms..."
+                                    setSearch={setSearchForms}
+                                    search={searchForms}/>
+                                <CreatorFormsTable forms={slicedForms}
+                                    name={
+                                        user!.name
+                                    }/>
+                            </CardContent>
+                        </Card>
+                    </TabsContent>
+
+                    <TabsContent value="responses" className="space-y-6">
+                        <Card>
+                            <TabHeader title="Form Responses" description="View and analyze responses to your forms"/>
+                            <CardContent>
+                                <SearchBar placeholder="Search responses..."
+                                    setSearch={setSearchResponses}
+                                    search={searchResponses}/>
+                                <ResponsesTable responses={slicedResponses}
+                                    name={
+                                        user!.name
+                                    }
+                                    isSummary={true}/>
+                            </CardContent>
+                        </Card>
+                    </TabsContent>
+                </Tabs>
+            </div>
         </div>
-      )
-  }
-  return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-50 to-purple-100 pb-20 pt-0 md:pt-0 w-full">
-      <DashboardHeader />
-      <div className="container mx-auto px-4 py-8">
-        <Tabs defaultValue="overview" className="space-y-6">
-          <AllTabs tabs={CREATOR_TABS} />
-
-          <TabsContent value="overview" className="space-y-6">
-            <AllCards cards={stateCardsData} />
-
-            <AllCharts
-              formResponsesData={formResponsesData}
-              formCreationData={formCreationData}
-              creatorActivityData={creatorActivityData} 
-              recentResponses={recentResponses}            
-            />
-          </TabsContent>
-
-          <TabsContent value="forms" className="space-y-6">
-            <Card>
-              <TabHeader title="My Forms" description="View and manage all your created forms" />
-              <CardContent>
-                <SearchBar placeholder="Search forms..." setSearch={setSearchForms} search={searchForms} />
-                <CreatorFormsTable forms={filteredForms} name={user!.name}/>
-              </CardContent>
-            </Card>
-          </TabsContent>
-
-          <TabsContent value="responses" className="space-y-6">
-            <Card>
-              <TabHeader title="Form Responses" description="View and analyze responses to your forms" />
-              <CardContent>
-                <SearchBar placeholder="Search responses..." setSearch={setSearchResponses} search={searchResponses} />
-                <ResponsesTable filteredResponses={filteredResponses} />
-              </CardContent>
-            </Card>
-          </TabsContent>
-        </Tabs>
-      </div>
-    </div>
-  )
+    )
 }
 
 export default CreatorDashboard

--- a/app/(main)/creator/[name]/dashboard/components/responses-table/hook/useFilter.ts
+++ b/app/(main)/creator/[name]/dashboard/components/responses-table/hook/useFilter.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from "react";
+import { ICreatorResponses } from "../../../types";
+
+export const useFilter = (responses: ICreatorResponses[]) => {
+    const [searchTerm, setSearchTerm] = useState<string>("");
+    const [filteredResponses, setFilteredResponses] = useState<ICreatorResponses[]>(responses);
+    const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+    useEffect(() => {
+        if(searchTerm) {
+            debounceRef.current = setTimeout(() => {
+                const filtered = responses.filter((response) => {
+                    return response.formTitle.toLowerCase().includes(searchTerm.toLowerCase()) 
+                    || response.respondentName.toLowerCase().includes(searchTerm.toLowerCase())
+                });
+                setFilteredResponses(filtered);
+            }, 500) 
+        }
+    
+        return () => {
+            if(debounceRef.current) {
+                clearTimeout(debounceRef.current); 
+            }
+        }
+    }, [searchTerm])
+    
+    return {
+        searchTerm,
+        setSearchTerm,
+        filteredResponses,
+    }
+}

--- a/app/(main)/creator/[name]/dashboard/components/responses-table/responsesTable.tsx
+++ b/app/(main)/creator/[name]/dashboard/components/responses-table/responsesTable.tsx
@@ -1,39 +1,53 @@
 "use client"
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow
+} from "@/components/ui/table"
 import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
     DropdownMenuLabel,
     DropdownMenuSeparator,
-    DropdownMenuTrigger,
+    DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu"
 import { Button } from "@/components/ui/button"
-import { MoreHorizontal, Eye, Download, Mail, Trash } from 'lucide-react'
-import { ICreatorResponses } from "../types"
+import { MoreHorizontal, Eye, Download, Mail } from 'lucide-react'
+import { ICreatorResponses } from "../../types"
 import Link from "next/link"
 import { useState } from "react"
 import DeleteDialog from "@/components/deleteDialog/deleteDialog"
-import ActionServices from "../services/action.service"
+import ActionServices from "../../services/action.service"
 import { toast } from "sonner"
+import { useFilter } from "./hook/useFilter"
+import SearchBar from "../searchBar"
 
 interface IProps {
-    filteredResponses: ICreatorResponses[]
+    responses: ICreatorResponses[];
+    isSummary?: boolean;
+    name: string;
 }
 
-const ResponsesTable = ({ filteredResponses }: IProps) => {
+const ResponsesTable = ({ responses, isSummary, name }: IProps) => {
     const [responseToDelete, setResponseToDelete] = useState<string | null>(null);
+    const { searchTerm, setSearchTerm, filteredResponses } = useFilter(responses);
+
     const handleDeleteResponse = async (id: string) => {
         const deletedResponse = await ActionServices.deleteResponse(id);
         if (deletedResponse) {
-            toast.success("Response deleted successfully!");
-        }
-        else {
-            toast.error("Failed to delete response!");
+        toast.success("Response deleted successfully!");
+        } else {
+        toast.error("Failed to delete response!");
         }
     }
+
     return (
         <div className="rounded-md border">
+        <SearchBar placeholder="Search A Response..." search={searchTerm} setSearch={setSearchTerm} />
         <Table>
             <TableHeader>
             <TableRow>
@@ -54,10 +68,18 @@ const ResponsesTable = ({ filteredResponses }: IProps) => {
             ) : (
                 filteredResponses.map((response) => (
                 <TableRow key={response.id}>
-                    <TableCell className="font-medium">{response.formTitle}</TableCell>
-                    <TableCell>{response.respondentName}</TableCell>
-                    <TableCell>{response.respondentEmail}</TableCell>
-                    <TableCell>{new Date(response.date).toISOString().split("T")[0]}</TableCell>
+                    <TableCell className="font-medium">
+                    {response.formTitle}
+                    </TableCell>
+                    <TableCell>
+                    {response.respondentName}
+                    </TableCell>
+                    <TableCell>
+                    {response.respondentEmail}
+                    </TableCell>
+                    <TableCell>
+                    {new Date(response.date).toISOString().split("T")[0]}
+                    </TableCell>
                     <TableCell className="text-right">
                     <DropdownMenu>
                         <DropdownMenuTrigger asChild>
@@ -71,7 +93,9 @@ const ResponsesTable = ({ filteredResponses }: IProps) => {
                         <DropdownMenuSeparator />
                         <DropdownMenuItem>
                             <Eye className="mr-2 h-4 w-4" />
-                            <Link href={`/review-response/${response.id}`}>{"View Details"}</Link>
+                            <Link href={`/review-response/${response.id}`}>
+                            View Details
+                            </Link>
                         </DropdownMenuItem>
                         <DropdownMenuItem>
                             <Download className="mr-2 h-4 w-4" />
@@ -82,10 +106,10 @@ const ResponsesTable = ({ filteredResponses }: IProps) => {
                             <span>Contact Respondent</span>
                         </DropdownMenuItem>
                         <DropdownMenuSeparator />
-                        <DeleteDialog
+                        <DeleteDialog 
                             itemToDelete={responseToDelete}
                             item={response}
-                            data={filteredResponses}
+                            data={responses}
                             setItemToDelete={setResponseToDelete}
                             itemsType="Response"
                             handleDeleteItem={handleDeleteResponse}
@@ -98,8 +122,20 @@ const ResponsesTable = ({ filteredResponses }: IProps) => {
             )}
             </TableBody>
         </Table>
+        {isSummary && (
+            <div className="flex justify-center p-4">
+            <Link href={`/creator/${name}/all-forms`}>
+                <Button 
+                variant="outline" 
+                className="text-purple-700 hover:bg-purple-50 hover:text-purple-900 transition"
+                >
+                View All Forms
+                </Button>
+            </Link>
+            </div>
+        )}
         </div>
     )
 }
 
-export default ResponsesTable
+export default ResponsesTable;

--- a/app/(main)/creator/[name]/dashboard/components/stateCard.tsx
+++ b/app/(main)/creator/[name]/dashboard/components/stateCard.tsx
@@ -1,13 +1,16 @@
 import { Card, CardContent } from "@/components/ui/card"
-import { ArrowUpIcon, ArrowDownIcon } from 'lucide-react'
-import type { ReactNode } from "react"
+import { ArrowUpIcon, ArrowDownIcon, LucideProps } from 'lucide-react'
+import type { ForwardRefExoticComponent, ReactNode, RefAttributes } from "react"
+import React from "react"
 
 interface IProps {
     stateTitle: string
     stateValue: string | number
     statePercentage: number
-    icon?: ReactNode
+    icon?: ForwardRefExoticComponent<Omit<LucideProps, "ref"> 
+            & RefAttributes<SVGSVGElement>>
 }
+
 
 const StateCard = (props: IProps) => {
     const { stateTitle, stateValue, statePercentage, icon } = props
@@ -21,7 +24,9 @@ const StateCard = (props: IProps) => {
                 <p className="text-sm font-medium text-muted-foreground">{stateTitle}</p>
                 <h3 className="text-2xl font-bold mt-1">{stateValue}</h3>
             </div>
-            <div className="h-10 w-10 rounded-full bg-purple-100 flex items-center justify-center">{icon}</div>
+            <div className="h-10 w-10 rounded-full bg-purple-100 flex items-center justify-center">
+                {icon && React.createElement(icon, { className: "h-5 w-5 text-purple-600" })}
+            </div>
             </div>
 
             <div className="flex items-center mt-4">

--- a/app/(main)/creator/[name]/dashboard/hooks/useDashboard.tsx
+++ b/app/(main)/creator/[name]/dashboard/hooks/useDashboard.tsx
@@ -3,6 +3,8 @@
 import { useState, useMemo, useEffect } from "react"
 import { ICreatorFormData, ICreatorResponses } from "../types"
 import { IFormTable } from "@/@types"
+import { generateStateCards } from "../utils/generateStateCards"
+import { summarizeForms, summarizeResponses } from "../utils/sliceAndSort"
 
 interface IProps {
     formsData: IFormTable[]
@@ -14,6 +16,12 @@ const useCreatorDashboard = ({ formsData, responses }: IProps) => {
     const [recentResponses, setRecentResponses] = useState<ICreatorResponses[]>([])
     const [searchForms, setSearchForms] = useState("")
     const [searchResponses, setSearchResponses] = useState("")
+    const totalForms = useMemo(() => formsData.length, [formsData])
+    const slicedForms = useMemo(() => summarizeForms(formsData), [formsData]);
+    const slicedResponses = useMemo(() => summarizeResponses(responses), [responses]);
+
+
+    const totalResponses = useMemo(() => formsData.reduce((sum, form) => sum + form.responses, 0), [formsData])
 
     useEffect(() => {
       if(responses.length > 5) {
@@ -23,33 +31,14 @@ const useCreatorDashboard = ({ formsData, responses }: IProps) => {
         setRecentResponses(responses)
       }
     }, [responses])
-    
-    const filteredForms = useMemo(() => {
-        if (!searchForms.trim()) return formsData
 
-        const searchTerm = searchForms.toLowerCase()
-        return formsData.filter(
-            (form) => form.name.toLowerCase().includes(searchTerm)
-        )
-    }, [formsData, searchForms])
+    const stateCardsData = useMemo(
+      () => generateStateCards(totalForms, totalResponses),
+    [totalForms, totalResponses]);
 
 
-    const filteredResponses = useMemo(() => {
-        if (!searchResponses.trim()) return responses
 
-        const searchTerm = searchResponses.toLowerCase()
-        return responses.filter(
-            (response) =>
-            response.formTitle.toLowerCase().includes(searchTerm) ||
-            response.respondentName.toLowerCase().includes(searchTerm) ||
-            response.respondentEmail.toLowerCase().includes(searchTerm),
-        )
-    }, [searchResponses])
-
-    const totalForms = useMemo(() => formsData.length, [formsData])
-
-
-    const totalResponses = useMemo(() => formsData.reduce((sum, form) => sum + form.responses, 0), [formsData])
+  
 
     const topPerformingForms = useMemo(() => {
         return [...formsData]
@@ -70,8 +59,8 @@ const useCreatorDashboard = ({ formsData, responses }: IProps) => {
   const conversionRateGrowth = 5; 
 
   return {
-    filteredForms,
-    filteredResponses,
+    slicedForms,
+    slicedResponses,
     totalForms,
     totalResponses,
     formGrowthRate,
@@ -82,6 +71,7 @@ const useCreatorDashboard = ({ formsData, responses }: IProps) => {
     recentResponses,
     searchForms,
     searchResponses,
+    stateCardsData,
     setSearchForms,
     setSearchResponses,
   }

--- a/app/(main)/creator/[name]/dashboard/page.tsx
+++ b/app/(main)/creator/[name]/dashboard/page.tsx
@@ -1,8 +1,6 @@
-import React from 'react'
 import CreatorDashboard from '../dashboard/components/creatorDashboard';
 import FetchServices from '../dashboard/services/fetchData.service'
-import formsRepo from '@/module/repositories/forms.repo';
-import responseRepo from '@/module/repositories/response.repo';
+
 // export const formData: IFormData[] = [
 //   {
 //     id: "f1",
@@ -112,7 +110,6 @@ const page = async (props: IProps) => {
         FetchServices.creatorActivityData(name),
         FetchServices.creatorResponses(name),
     ]);
-
   return (
     <CreatorDashboard 
       formsData={formData} 

--- a/app/(main)/creator/[name]/dashboard/types.ts
+++ b/app/(main)/creator/[name]/dashboard/types.ts
@@ -1,3 +1,5 @@
+import { LucideProps } from "lucide-react"
+import { ForwardRefExoticComponent, RefAttributes } from "react"
 
 export interface IFormCreationData {
     date: string
@@ -29,5 +31,13 @@ export interface ICreatorResponses {
     respondentName: string,
     respondentEmail: string,
     date: string,
+}
+
+export interface IStateCard {
+    stateTitle: string;
+    stateValue: number;
+    statePercentage: number;
+    icon: ForwardRefExoticComponent<Omit<LucideProps, "ref"> 
+            & RefAttributes<SVGSVGElement>>
 }
 

--- a/app/(main)/creator/[name]/dashboard/utils/generateStateCards.ts
+++ b/app/(main)/creator/[name]/dashboard/utils/generateStateCards.ts
@@ -1,0 +1,26 @@
+import { BarChart, FileText, Users } from "lucide-react"
+import { IStateCard } from "../types"
+
+export const generateStateCards = (totalForms: number, totalResponses: number): IStateCard[] => {
+    const stateCards: IStateCard[] = [
+        {
+            stateTitle: "Total Forms",
+            stateValue: totalForms,
+            statePercentage: 10,
+            icon: FileText,
+        },
+        {
+            stateTitle: "Active Forms",
+            stateValue: 8,
+            statePercentage: 15,
+            icon: BarChart,
+        },
+        {
+            stateTitle: "Total Responses",
+            stateValue: totalResponses,
+            statePercentage: 12,
+            icon: Users,
+        },
+    ]
+    return stateCards
+}

--- a/app/(main)/creator/[name]/dashboard/utils/sliceAndSort.ts
+++ b/app/(main)/creator/[name]/dashboard/utils/sliceAndSort.ts
@@ -1,0 +1,20 @@
+import { IFormTable } from "@/@types";
+import { ICreatorResponses } from "../types";
+
+function parseDate(dateStr: string): Date {
+    const [day, month, year] = dateStr.split("/").map(Number);
+    return new Date(year, month - 1, day); 
+}
+export function summarizeForms(forms: IFormTable[]): IFormTable[] {
+    return forms
+        .sort((a, b) => b.responses - a.responses)
+        .slice(0, 5);
+}
+
+export function summarizeResponses(responses: ICreatorResponses[]): ICreatorResponses[] {
+    return responses
+        .sort((a, b) => parseDate(b.date).getTime() - parseDate(a.date).getTime())
+        .slice(0, 5);
+}
+
+

--- a/components/forms-table/actions/form.action.ts
+++ b/components/forms-table/actions/form.action.ts
@@ -1,21 +1,19 @@
-import { connection } from "@/DB/connection";
-import formsService from "@/module/services/forms.service";
+export const deleteForm = async (formId: string) => {
+    const localUrl = process.env.NEXT_PUBLIC_URL;
 
-class FormActions {
-    async deleteForm(formId: string) {
-        await connection();
-        try {
-            const deletedForm = await formsService.deleteForm(formId);
-            return deletedForm;
-        }   
-        catch (error) {
-            if(error instanceof Error) {
-                console.error(error.message);
-            }
-            console.error("Failed to Delete the form!");
-            return null;
-        }
+    try {
+        const res = await fetch(`${localUrl}/api/delete-form`, {
+        method: "DELETE",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ formId }),
+        });
+
+        const { formsData } = await res.json();
+        return formsData;
+    } catch (err: any) {
+        console.error(err.message || "Failed to delete the form!");
+        return null;
     }
-}
-
-export default new FormActions();
+};

--- a/components/forms-table/formsTable.tsx
+++ b/components/forms-table/formsTable.tsx
@@ -25,7 +25,9 @@ import { toast } from "sonner";
 import SearchBar from "../text-search-bar/searchBar";
 import { useFilter } from "./hook/useFilter";
 import Link from "next/link";
-import formAction from "./actions/form.action";
+import { deleteForm } from "./actions/form.action";
+
+
 
 interface IProps {
     forms: IFormTable[];
@@ -40,7 +42,7 @@ const FormsTable = (props: IProps) => {
     const { setSearchTerm, searchTerm, filteredForms } = useFilter(forms);
 
     const handleFormDelete = async (formId: string) => {
-        const deletedForm = await formAction.deleteForm(formId);
+        const deletedForm = await deleteForm(formId);
         if (deletedForm) {
             toast.success(`Form: ${deletedForm.title}, deleted successfully`);
         }

--- a/components/user-table/actions/user.action.ts
+++ b/components/user-table/actions/user.action.ts
@@ -1,21 +1,21 @@
-import { connection } from "@/DB/connection";
-import userService from "@/module/services/user.service";
-
-class UserAction {
-    async deleteUser(userId: string) {
-        await connection();
-        try {
-            const deletedUser = await userService.deleteUser(userId);
-            return deletedUser;
-        }
-        catch (err) {
-            if (err instanceof Error) {
-                console.error(err.message);
-            }
-            console.error("Failed to delete the user!");
-            return null;
-        }
+export const deleteUser = async(userId: string) => {
+    const localUrl = process.env.NEXT_PUBLIC_URL;
+    try {
+        const res = await fetch(`${localUrl}/api/delete-form`, {
+            method: "DELETE",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ userId })
+        });
+        const {usersData} = await res.json();
+        return usersData
+    }
+    catch (err: any) {
+        console.error(err.message || "Failed to delete the user!");
+        return null;
     }
 }
 
-export default new UserAction();
+
+

--- a/components/user-table/userTable.tsx
+++ b/components/user-table/userTable.tsx
@@ -28,10 +28,11 @@ import {
 import {toast} from 'sonner';
 import {useRouter} from 'next/navigation';
 import DeleteDialog from '@/components/deleteDialog/deleteDialog';
-import userAction from './actions/user.action';
+
 import { getLimitedUsers } from './lib/getLimitedUsers';
 import { useFilter } from './hooks/useFilter';
 import SearchBar from '../text-search-bar/searchBar';
+import { deleteUser } from './actions/user.action';
 
 interface IProps {
     users: IUserData[];
@@ -48,7 +49,7 @@ const UsersTable = (props: IProps) => {
         filteredUsers
     } = useFilter(users);
     const handleDeleteUser = async (userId: string) => {
-        const deletedUser = await userAction.deleteUser(userId);
+        const deletedUser = await deleteUser(userId);
         if (deletedUser) {
             toast.success(`User: ${deletedUser.email}, deleted successfully`);
         } else {


### PR DESCRIPTION
refactor(creator-dashboard): restructure responses table and add state cards generation

Moved the responses table to a dedicated directory and added a `useFilter` hook for search functionality. Introduced a `generateStateCards` utility to centralize state card data generation. Updated the `useDashboard` hook to utilize the new utility and removed redundant code. Improved maintainability and organization of the dashboard components.