### PR TITLE
FA-90: delete form responses.

### DIFF
--- a/module/repositories/response.repo.ts
+++ b/module/repositories/response.repo.ts
@@ -2,7 +2,7 @@ import { IResponseFromDB, IResponsePopulatedUser, IUserFromDB, IUserResponseTabl
 import responseModel from "@/DB/models/response.model";
 import mongoose from "mongoose";
 import userRepo from "./user.repo";
-import { ICreatorResponses } from "@/app/(main)/creator/dashboard/types";
+
 import { getDateOnly } from "@/lib/dateUtils";
 import { IResponseDetailsFromDB } from "../services/types";
 
@@ -71,6 +71,9 @@ class ResponseRepo {
     }
     async deleteResponse(responseId: string) {
         return await responseModel.findByIdAndDelete(responseId);
+    }
+    async deleteFormResponses(formId: string) {
+        return await responseModel.deleteMany({ formId: formId });
     }
 }
 

--- a/module/services/forms.service.ts
+++ b/module/services/forms.service.ts
@@ -2,6 +2,7 @@ import { IForm, IFormFromDB } from "@/@types";
 import formsRepo from "../repositories/forms.repo";
 
 import userRepo from "../repositories/user.repo";
+import responseService from "./response.service";
 class FormServices {
     async getFormById(formId: string): Promise<IFormFromDB | null> {
             const form = await formsRepo.getFormById(formId);
@@ -40,6 +41,10 @@ class FormServices {
         const form = await formsRepo.getFormById(formId);
         if(!form) {
             throw new Error("Form not found");
+        }
+        const deleteResponses = await responseService.deleteFromResponses(String(form._id));
+        if(!deleteResponses) {
+            throw new Error("Failed to delete responses");
         }
         const deletedForm = await formsRepo.deleteForm(formId);
         return deletedForm;

--- a/module/services/response.service.ts
+++ b/module/services/response.service.ts
@@ -46,6 +46,10 @@ class ResponseService {
         }
         return response;
     }
+
+    async deleteFromResponses(formId: string) {
+        return await responseRepo.deleteFormResponses(formId);
+    }
 }
 
 export default new ResponseService();


### PR DESCRIPTION
feat: add functionality to delete form responses when deleting a form
This commit introduces a new method `deleteFromResponses` in the `ResponseService` to handle the deletion of all responses associated with a specific form. The `deleteFormResponses` method is added to the `ResponseRepo` to perform the actual deletion in the database. This ensures that when a form is deleted, all its related responses are also removed, maintaining data consistency.