### PR TITLE
FA-91: Fixing state cards bug

### DIFF
--- a/app/api/dashboard/delete-user/route.ts
+++ b/app/api/dashboard/delete-user/route.ts
@@ -1,6 +1,8 @@
 import { IUserFromDB } from "@/@types";
 import { connection } from "@/DB/connection";
 import dashboardRepo from "@/module/repositories/admin/dashboard.repo";
+import formsService from "@/module/services/forms.service";
+import responseService from "@/module/services/response.service";
 import userService from "@/module/services/user.service";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -11,16 +13,22 @@ export const DELETE = async (req: NextRequest) => {
         if (!userId) {
             return NextResponse.json({ message: "User ID is required!" }, { status: 401 });
         }
+
+        await formsService.deleteUserForms(userId);
+
+        await responseService.deleteUserResponses(userId);
+
         const deletedUser: IUserFromDB | null = await userService.deleteUser(userId);
         if (!deletedUser) {
             return NextResponse.json({ message: "Invalid user ID!" }, { status: 401 });
         }
+
         return NextResponse.json({ deletedUser }, { status: 200 });
     }
     catch (err) {
         if (err instanceof Error) {
             return NextResponse.json({ message: err.message }, { status: 401 });
         }
+        return NextResponse.json({ message: "Something went wrong!" }, { status: 500 });
     }
-    return NextResponse.json({ message: "Something went wrong!" }, { status: 500 });
 }

--- a/app/api/delete-form/route.ts
+++ b/app/api/delete-form/route.ts
@@ -1,6 +1,7 @@
 import { IFormFromDB, IUserFromDB } from "@/@types";
 import { connection } from "@/DB/connection";
 import dashboardRepo from "@/module/repositories/admin/dashboard.repo";
+import responseRepo from "@/module/repositories/response.repo";
 import formsService from "@/module/services/forms.service";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -11,16 +12,20 @@ export const DELETE = async (req: NextRequest) => {
         if (!formId) {
             return NextResponse.json({ message: "Form ID is required!" }, { status: 401 });
         }
+
+        await responseRepo.deleteFormResponses(formId);
+
         const deletedForm: IFormFromDB | null = await formsService.deleteForm(formId); 
         if (!deletedForm) {
             return NextResponse.json({ message: "Invalid form ID!" }, { status: 401 });
         }
+
         return NextResponse.json({ deletedForm }, { status: 200 });
     }
     catch (err) {
         if (err instanceof Error) {
             return NextResponse.json({ message: err.message }, { status: 401 });
         }
+        return NextResponse.json({ message: "Something went wrong!" }, { status: 500 });
     }
-    return NextResponse.json({ message: "Something went wrong!" }, { status: 500 });
 }

--- a/components/user-table/actions/user.action.ts
+++ b/components/user-table/actions/user.action.ts
@@ -1,7 +1,7 @@
 export const deleteUser = async(userId: string) => {
     const localUrl = process.env.NEXT_PUBLIC_URL;
     try {
-        const res = await fetch(`${localUrl}/api/delete-form`, {
+        const res = await fetch(`${localUrl}/api/delete-user`, {
             method: "DELETE",
             headers: {
                 "Content-Type": "application/json",

--- a/module/repositories/forms.repo.ts
+++ b/module/repositories/forms.repo.ts
@@ -49,6 +49,9 @@ class FormsRepo {
     async deleteForm (formId: string) {
         return await FormModel.findByIdAndDelete(formId).lean<IFormFromDB>();
     }
+    async deleteUserForms (userId: string) {
+        return await FormModel.deleteMany({creatorId: userId});
+    }
 }
 
 export default new FormsRepo();

--- a/module/repositories/response.repo.ts
+++ b/module/repositories/response.repo.ts
@@ -5,6 +5,7 @@ import userRepo from "./user.repo";
 
 import { getDateOnly } from "@/lib/dateUtils";
 import { IResponseDetailsFromDB } from "../services/types";
+import { deleteUser } from "@/components/user-table/actions/user.action";
 
 class ResponseRepo {
     async getResponseById(responseId: string) {
@@ -74,6 +75,10 @@ class ResponseRepo {
     }
     async deleteFormResponses(formId: string) {
         return await responseModel.deleteMany({ formId: formId });
+    }
+
+    async deleteUserResponses(userId: string) {
+        return await responseModel.deleteMany({ userId: userId });
     }
 }
 

--- a/module/services/admin/dashboard.service.ts
+++ b/module/services/admin/dashboard.service.ts
@@ -100,10 +100,5 @@ class DashboardService {
         })
         return formResponseData;
     }
-
-    async deleteForm(formId: string) {
-        const deletedForm: IFormFromDB | null = await dashboardRepo.deleteForm(formId);
-        return deletedForm;
-    }
 }
 export default new DashboardService();

--- a/module/services/forms.service.ts
+++ b/module/services/forms.service.ts
@@ -35,19 +35,26 @@ class FormServices {
     }
 
     async deleteForm (formId: string) {
-        if(!formId) {
-            throw new Error("No form id provided");
-        }
         const form = await formsRepo.getFormById(formId);
         if(!form) {
             throw new Error("Form not found");
         }
-        const deleteResponses = await responseService.deleteFromResponses(String(form._id));
-        if(!deleteResponses) {
-            throw new Error("Failed to delete responses");
-        }
+        // const deleteResponses = await responseService.deleteFromResponses(String(form._id));
+        // if(!deleteResponses) {
+        //     throw new Error("Failed to delete responses");
+        // }
         const deletedForm = await formsRepo.deleteForm(formId);
         return deletedForm;
+    }
+    deleteUserForms = async (userId: string) => {
+        const forms = await formsRepo.getCreatorForm(userId);
+        if(forms.length > 0) {
+            const deletedForms = await formsRepo.deleteUserForms(userId);
+            if(!deletedForms) {
+                throw new Error("Error deleting user forms");
+            }
+        }
+        return forms;
     }
 }
 export default new FormServices();

--- a/module/services/response.service.ts
+++ b/module/services/response.service.ts
@@ -48,7 +48,18 @@ class ResponseService {
     }
 
     async deleteFromResponses(formId: string) {
-        return await responseRepo.deleteFormResponses(formId);
+        const responses = await responseRepo.deleteFormResponses(formId);
+        if(!responses) {
+            throw new Error("Error deleting user responses");
+        }
+        return responses;
+    }
+    async deleteUserResponses(userId: string) {
+        const responses = await responseRepo.deleteUserResponses(userId);
+        if(!responses) {
+            throw new Error("Error deleting user responses");
+        }
+        return responses;
     }
 }
 

--- a/module/services/user.service.ts
+++ b/module/services/user.service.ts
@@ -1,12 +1,22 @@
 import { IUserFromDB } from "@/@types";
 import userRepo from "../repositories/user.repo";
+import formsRepo from "../repositories/forms.repo";
+import responseRepo from "../repositories/response.repo";
 
 class UserService {
     async findUserById(id: string) {
         return await userRepo.getUserById(id);
     }
     async deleteUser(userId: string) {
+        const user = await userRepo.getUserById(userId);
+        if(!user) {
+            throw new Error("User not found");
+        }
+
         const deletedUser: IUserFromDB | null = await userRepo.deleteUser(userId);
+        if(!deletedUser) {
+            throw new Error("Error deleting user");
+        }
         return deletedUser;
     }
 }


### PR DESCRIPTION
feat: add functionality to delete form responses when deleting a form

This commit introduces a new method deleteFromResponses in the ResponseService to handle the deletion of all responses associated with a specific form. The deleteFormResponses method is added to the ResponseRepo to perform the actual deletion in the database. This ensures that when a form is deleted, all its related responses are also removed, maintaining data consistency.