### PR TITLE
FA-131: feat(auth) implement access control for protected routes

### DIFF
--- a/@types/access.ts
+++ b/@types/access.ts
@@ -1,0 +1,6 @@
+export enum AccessRights {
+        "unauthorized",
+        "allowed",
+        "notFound"
+    }
+export type AccessRightsType = keyof typeof AccessRights;

--- a/app/(main)/answer-form/service/accessRights.service.ts
+++ b/app/(main)/answer-form/service/accessRights.service.ts
@@ -1,13 +1,9 @@
-    "seerver-only";
+    "server-only";
+import { AccessRightsType } from "@/@types/access";
     import { connection } from "@/DB/connection";
     import { getToken } from "@/lib/getToken"
     import formsService from "@/module/services/forms.service";
-    enum AccessRights {
-        "unauthorized",
-        "allowed",
-        "notFound"
-    }
-    type AccessRightsType = keyof typeof AccessRights;
+
 
     export const  getAccessRights = async (formId: string): Promise<AccessRightsType> => {
         const token = await getToken();
@@ -19,10 +15,15 @@
         }
         else {
             await connection();
-            const form = await formsService.getFormById(formId);
-            if(!form) return "notFound";
-            const allowed = form.allowedUsers?.map(userId => String(userId)) || [];
-            if(form.isPublic || allowed.includes(token.userId)) return "allowed";
-            return "unauthorized";
+            try {
+                const form = await formsService.getFormById(formId);
+                if(!form) return "notFound";
+                const allowed = form.allowedUsers?.map(userId => String(userId)) || [];
+                if(form.isPublic || allowed.includes(token.userId)) return "allowed";
+                return "unauthorized";
+            }
+            catch(e) {
+                return "notFound";
+            }
         }
     }

--- a/app/(main)/available-forms/[name]/page.tsx
+++ b/app/(main)/available-forms/[name]/page.tsx
@@ -1,11 +1,17 @@
 import React from 'react'
 import fetchDataService from '../service/fetchData.service';
 import FormsTable from '@/components/forms-table/formsTable';
+import authService from '@/module/services/auth.service';
+import { unauthorized } from 'next/navigation';
 interface IProps {
     params: Promise<{name: string}>
 }
 const AvailableForms = async(props: IProps) => {
-    const name = decodeURIComponent((await props.params).name); 
+    const name = decodeURIComponent((await props.params).name);
+    const access = await authService.validateUser(name);
+    if(!access) {
+        unauthorized();
+    }
     const availableForms = await fetchDataService.getAvailableForms(name);
     return (
         <FormsTable forms= {availableForms} />

--- a/app/(main)/creator/[name]/all-responses/page.tsx
+++ b/app/(main)/creator/[name]/all-responses/page.tsx
@@ -2,14 +2,20 @@ import dashboardService from '@/module/services/creator/dashboard.service';
 import React from 'react'
 import fetchDataService from '../dashboard/services/fetchData.service';
 import ResponsesTable from '@/components/responses-table/responsesTable';
+import authService from '@/module/services/auth.service';
+import { unauthorized } from 'next/navigation';
 interface IProps {
     params: Promise<{name: string}>
 }
 const page = async (props: IProps) => {
     const name = decodeURIComponent((await props.params).name);
+    const access = await authService.validateUser(name);
+    if(!access) {
+        unauthorized();
+    }
     const responses = await fetchDataService.creatorResponses(name)
     return (
-        <ResponsesTable responses={responses} name = {name}/>
+        <ResponsesTable responses={responses} />
     )
 }
 

--- a/app/(main)/creator/[name]/dashboard/page.tsx
+++ b/app/(main)/creator/[name]/dashboard/page.tsx
@@ -1,5 +1,7 @@
+import authService from '@/module/services/auth.service';
 import CreatorDashboard from '../dashboard/components/creatorDashboard';
 import FetchServices from '../dashboard/services/fetchData.service'
+import { unauthorized } from 'next/navigation';
 
 // export const formData: IFormData[] = [
 //   {
@@ -96,7 +98,10 @@ interface IProps {
 }
 const page = async (props: IProps) => {
       const name = decodeURIComponent((await props.params).name); 
-
+      const access = await authService.validateUser(name);
+      if(!access) {
+          unauthorized();
+      }
       const [
         formData,
         formCreationData,

--- a/app/(main)/form-answers/[name]/[id]/page.tsx
+++ b/app/(main)/form-answers/[name]/[id]/page.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { getFormAnswers } from '../../service/answers.service';
 import ResponsesTable from '@/components/responses-table/responsesTable';
+import { getAccessRights } from '../../service/accessRights.service';
+import { notFound, unauthorized } from 'next/navigation';
 
 interface IProps {
     params: Promise<{id: string, name: string}>
@@ -8,9 +10,16 @@ interface IProps {
 const page = async(props: IProps) => {
     const {id, name} = await props.params;
     const validName = decodeURIComponent(name);
-    const {message, answers} = await getFormAnswers(id, validName);
+    const permission = await getAccessRights(id, name);
+    if(permission === "unauthorized") {
+        unauthorized()
+    }
+    if(permission === "notFound") {
+        notFound();
+    }
+    const { answers} = await getFormAnswers(id, validName);
     return (
-        <ResponsesTable responses={answers} name={validName}/>
+        <ResponsesTable responses={answers} />
     )
 }
 

--- a/app/(main)/form-answers/service/accessRights.service.ts
+++ b/app/(main)/form-answers/service/accessRights.service.ts
@@ -1,20 +1,26 @@
 "seerver-only";
+import { AccessRightsType } from "@/@types/access";
 import { connection } from "@/DB/connection";
 import { getToken } from "@/lib/getToken"
 import formsService from "@/module/services/forms.service";
 
-export const  getAccessRights = async (formId: string) => {
+export const  getAccessRights = async (formId: string, name: string): Promise<AccessRightsType> => {
     const token = await getToken();
     if(!token) {
-        return false;
+        return "unauthorized";
     }
-    if(token.role === "admin") {
-        return true;
+
+    if(token.role === "admin" || token.name !== name) {
+        return "unauthorized";
     }
+
     else {
         await connection();
         const form = await formsService.getFormById(formId);
-        if(!form || String(form.creatorId) !== token.userId) return false;
-        return true;
+        if(!form) {
+            return "notFound";
+        }
+        if( String(form.creatorId) !== token.userId) return "unauthorized";
+        return "allowed";
     }
 }

--- a/components/responses-table/responsesTable.tsx
+++ b/components/responses-table/responsesTable.tsx
@@ -19,25 +19,25 @@ import {
 import { Button } from "@/components/ui/button"
 import { MoreHorizontal, Eye, Download, Mail } from "lucide-react"
 import Link from "next/link"
-import { useState } from "react"
+import { useContext, useState } from "react"
 import DeleteDialog from "@/components/deleteDialog/deleteDialog"
 import { toast } from "sonner"
 import { useFilter } from "./hook/useFilter"
 import { UserRoles } from "@/@types"
 import { ICreatorResponses } from "@/app/(main)/creator/[name]/dashboard/types"
 import SearchBar from "../text-search-bar/searchBar"
+import { AuthContext } from "@/providers/auth/authProvider"
+import TablesLoader from "../tables-loader/tablesLoader"
 
 interface IProps {
     responses: ICreatorResponses[]
     isSummary?: boolean
-    name: string
-    role?: UserRoles
 }
 
-const ResponsesTable = ({ responses, isSummary, name, role }: IProps) => {
+const ResponsesTable = ({ responses, isSummary }: IProps) => {
     const [responseToDelete, setResponseToDelete] = useState<string | null>(null)
     const { searchTerm, setSearchTerm, filteredResponses } = useFilter(responses)
-
+    const {user, isLoading} = useContext(AuthContext);
     const handleDeleteResponse = async (id: string) => {
         // const deletedResponse = await ActionServices.deleteResponse(id)
         // if (deletedResponse) {
@@ -46,7 +46,12 @@ const ResponsesTable = ({ responses, isSummary, name, role }: IProps) => {
         // toast.error("Failed to delete response!")
         // }
     }
-
+    if(isLoading) {
+        return <TablesLoader itemName={"Response"}/>
+    }
+    if(!user) {
+        return null;
+    }
     return (
         <div className="rounded-lg border border-cyan-500/30 bg-gradient-to-br from-blue-900/40 via-indigo-800/30 to-cyan-600/40 backdrop-blur-md shadow-2xl w-full m-2 ring-1 ring-cyan-500/20">
         <SearchBar placeholder="Search A Response..." search={searchTerm} setSearch={setSearchTerm} />
@@ -133,7 +138,7 @@ const ResponsesTable = ({ responses, isSummary, name, role }: IProps) => {
 
         {isSummary && (
             <div className="flex justify-center p-4">
-            <Link href={`/${role || "creator"}/${name}/all-responses`}>
+            <Link href={`/${user.role || "creator"}/${user.name}/all-responses`}>
                 <Button
                 variant="outline"
                 className="text-cyan-400 border-cyan-400/40 hover:bg-gradient-to-r hover:from-blue-700/20 hover:to-cyan-600/20 transition"

--- a/module/services/auth.service.ts
+++ b/module/services/auth.service.ts
@@ -6,6 +6,7 @@ import { comparePassword, hashPassword } from "@/lib/compareAndHash";
 import xss from "xss";
 import { generateToken } from "@/lib/generateAndVerifyToken";
 import { cookies } from "next/headers";
+import { getToken } from "@/lib/getToken";
 
 class AuthService {
     async signUp(user: IUser) {
@@ -66,6 +67,17 @@ class AuthService {
             user,
             token,
         };
-    }   
+    }
+    
+    async validateUser (username: string)  {
+        const token = await getToken();
+        if(!token) {
+            return false;
+        }
+        if(token.name === username) {
+            return true;
+        }
+        return false;
+    }
 }
 export default new AuthService();


### PR DESCRIPTION
- Add AccessRights enum and type for standardized permission handling
- Implement validateUser method in auth service to check user access
- Add access control checks to creator dashboard, available forms, responses pages
- Refactor access rights service to use new AccessRights type
- Update responses table to use auth context instead of props