### PR TITLE
docs(pages): update metadata descriptions for all pages to be more specific

### DIFF
--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -3,7 +3,7 @@ import SignIn from "./components/signin-page"
 export const metadata = {
     title: "Sign-In | FormAI",
     description:
-        "Powerful admin dashboard to oversee form submissions, manage users, and control platform settings in one centralized interface.",
+        "Sign in to your Form AI Builder account and take control of your intelligent forms. Secure and seamless access to your dashboard.",
     keywords: [
         "Login",
         "signin",
@@ -17,7 +17,7 @@ export const metadata = {
     openGraph: {
         title: "Sign-In | FormAI",
         description:
-        "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+        "Access your Form AI Builder account to create, manage, and analyze smart forms powered by AI.",
         url: "/sign-in",
         siteName: "FormAI",
         images: ["/logo.png"],
@@ -29,7 +29,7 @@ export const metadata = {
         creator: "@Moamen-Yazouri",
         title: "Sign-In | FormAI",
         description:
-            "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+            "Access your Form AI Builder account to create, manage, and analyze smart forms powered by AI.",
         images: ["/logo.png"],
     },
     other: {

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -3,7 +3,7 @@ import SignUp from "./components/signup-form/signup-page";
 export const metadata = {
     title: "Sign-Up | FormAI",
     description:
-        "Powerful admin dashboard to oversee form submissions, manage users, and control platform settings in one centralized interface.",
+        "Sign up for Form AI Builder to unlock powerful tools for creating, sharing, and analyzing intelligent forms tailored to your business needs.",
     keywords: [
         "signup",
         "sign-up",
@@ -15,7 +15,7 @@ export const metadata = {
     openGraph: {
         title: "Sign-Up | FormAI",
         description:
-        "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+        "Create your Form AI Builder account and start building intelligent, dynamic forms powered by AI.",
         url: "/sign-up",
         siteName: "FormAI",
         images: ["/logo.png"],
@@ -27,7 +27,7 @@ export const metadata = {
         creator: "@Moamen-Yazouri",
         title: "Sign-Up | FormAI",
         description:
-            "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+            "Create your Form AI Builder account and start building intelligent, dynamic forms powered by AI.",
         images: ["/logo.png"],
     },
     other: {

--- a/app/(main)/answer-form/[id]/page.tsx
+++ b/app/(main)/answer-form/[id]/page.tsx
@@ -4,7 +4,7 @@ import { handleAccess } from "@/lib/triggerCoventions";
 export const metadata = {
     title: "Answer Form | FormAI",
     description:
-        "Powerful admin dashboard to oversee form submissions, manage users, and control platform settings in one centralized interface.",
+        "Answer AI-enhanced forms designed for speed and accuracy. Submit your responses with ease using Form AI Builder.",
     keywords: [
         "Answer Form",
     ],
@@ -13,7 +13,7 @@ export const metadata = {
     openGraph: {
         title: "Answer Form | FormAI",
         description:
-        "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+            "Fill out this AI-powered form to provide your input. Fast, responsive, and tailored to your needs.",
         url: "/answer-form/[id]",
         siteName: "FormAI",
         images: ["/logo.png"],
@@ -25,7 +25,7 @@ export const metadata = {
         creator: "@Moamen-Yazouri",
         title: "Answer Form | FormAI",
         description:
-            "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+            "Fill out this AI-powered form to provide your input. Fast, responsive, and tailored to your needs.",
         images: ["/logo.png"],
     },
     other: {
@@ -34,19 +34,19 @@ export const metadata = {
     },
 };
 interface IProps {
-  params: Promise<{id: string}>
+    params: Promise<{id: string}>
 }
 
 
 const AnswerFormPage = async (props: IProps) => {
-  const id = (await props.params).id;
-  const accessRight = await getAccessRights(id);
-  handleAccess(accessRight);
-  
-  return (
-    <FormTemplate id={id} isPreview={false}  isView={false}/>
+    const id = (await props.params).id;
+    const accessRight = await getAccessRights(id);
+    handleAccess(accessRight);
     
-  );
+    return (
+        <FormTemplate id={id} isPreview={false}  isView={false}/>
+
+    );
 };
 
 export default AnswerFormPage;

--- a/app/(main)/available-forms/[name]/page.tsx
+++ b/app/(main)/available-forms/[name]/page.tsx
@@ -4,7 +4,7 @@ import FormsTable from '@/components/forms-table/formsTable';
 export const metadata = {
     title: "Available Forms | FormAI",
     description:
-        "Powerful admin dashboard to oversee form submissions, manage users, and control platform settings in one centralized interface.",
+        "Discover and access a wide range of available forms created using Form AI Builder. Join surveys, provide feedback, or submit responses easily.",
     keywords: [
         "view forms",
         "available forms",
@@ -15,7 +15,7 @@ export const metadata = {
     openGraph: {
         title: "Available Forms | FormAI",
         description:
-        "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+        "Explore all available forms created by the community. Browse, preview, and participate in AI-enhanced data collection.",
         url: "/available-forms/[name]",
         siteName: "FormAI",
         images: ["/logo.png"],
@@ -27,7 +27,7 @@ export const metadata = {
         creator: "@Moamen-Yazouri",
         title: "Available Forms | FormAI",
         description:
-            "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+            "Explore all available forms created by the community. Browse, preview, and participate in AI-enhanced data collection.",
         images: ["/logo.png"],
     },
     other: {

--- a/app/(main)/creator/[name]/all-responses/page.tsx
+++ b/app/(main)/creator/[name]/all-responses/page.tsx
@@ -4,7 +4,7 @@ import ResponsesTable from '@/components/responses-table/responsesTable';
 export const metadata = {
     title: "Creator Forms Responses | FormAI",
     description:
-        "Powerful admin dashboard to oversee form submissions, manage users, and control platform settings in one centralized interface.",
+        "Access all responses submitted to your forms. Track feedback, export data, and extract insights using our intuitive AI-powered dashboard.",
     keywords: [
         "creator responses management",
         "view all responses",
@@ -16,7 +16,7 @@ export const metadata = {
     openGraph: {
         title: "All forms | FormAI",
         description:
-        "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+        "View and analyze responses submitted to your forms. Gain insights and manage data effortlessly with Form AI Builder.",
         url: "/creator/[name]/all-responses",
         siteName: "FormAI",
         images: ["/logo.png"],
@@ -28,7 +28,7 @@ export const metadata = {
         creator: "@Moamen-Yazouri",
         title: "Creator Forms Responses | FormAI",
         description:
-            "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+            "View and analyze responses submitted to your forms. Gain insights and manage data effortlessly with Form AI Builder.",
         images: ["/logo.png"],
     },
     other: {

--- a/app/(main)/creator/[name]/dashboard/page.tsx
+++ b/app/(main)/creator/[name]/dashboard/page.tsx
@@ -3,7 +3,7 @@ import FetchServices from '../dashboard/services/fetchData.service';
 export const metadata = {
     title: "Creator Dashboard | FormAI",
     description:
-        "Powerful admin dashboard to oversee form submissions, manage users, and control platform settings in one centralized interface.",
+        "Access your creator dashboard to build new forms, view response metrics, and manage your published forms—all in one place.",
     keywords: [
         "creator management",
         "view creator forms",
@@ -16,7 +16,7 @@ export const metadata = {
     openGraph: {
         title: "Creator Dashboard | FormAI",
         description:
-        "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+          "Manage your forms, track response data, and build smarter user experiences with your personalized dashboard.",
         url: "/creator/[name]/dashboard",
         siteName: "FormAI",
         images: ["/logo.png"],
@@ -28,7 +28,7 @@ export const metadata = {
         creator: "@Moamen-Yazouri",
         title: "Creator Dashboard | FormAI",
         description:
-            "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+            "Manage your forms, track response data, and build smarter user experiences with your personalized dashboard.",
         images: ["/logo.png"],
     },
     other: {

--- a/app/(main)/form-answers/[name]/[id]/page.tsx
+++ b/app/(main)/form-answers/[name]/[id]/page.tsx
@@ -6,7 +6,7 @@ import { handleAccess } from '@/lib/triggerCoventions';
 export const metadata = {
     title: "Form Answers | FormAI",
     description:
-        "Powerful admin dashboard to oversee form submissions, manage users, and control platform settings in one centralized interface.",
+        "View and manage detailed responses for your form. Gain insights from user input and track engagement in real time.",
     keywords: [
         "admin answers management",
         "creator answers management",
@@ -20,7 +20,7 @@ export const metadata = {
     openGraph: {
         title: "Form Answers | FormAI",
         description:
-        "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+        "Review individual responses submitted to your form. Filter, analyze, and manage data effortlessly with AI-enhanced tools.",
         url: "/form-answers/[name]/[id]",
         siteName: "FormAI",
         images: ["/logo.png"],
@@ -32,7 +32,7 @@ export const metadata = {
         creator: "@Moamen-Yazouri",
         title: "Form Answers | FormAI",
         description:
-            "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+            "Review individual responses submitted to your form. Filter, analyze, and manage data effortlessly with AI-enhanced tools.",
         images: ["/logo.png"],
     },
     other: {

--- a/app/(main)/form-generator/page.tsx
+++ b/app/(main)/form-generator/page.tsx
@@ -2,7 +2,7 @@ import FormGeneratorPage from './components/formGeneratorPage';
 export const metadata = {
     title: "Form Generator | FormAI",
     description:
-        "Powerful admin dashboard to oversee form submissions, manage users, and control platform settings in one centralized interface.",
+        "Build smart forms using our AI-powered generator. Customize layouts, set conditions, and launch dynamic forms in minutes.",
     keywords: [
         "generate forms",
         "build forms",
@@ -14,7 +14,7 @@ export const metadata = {
     openGraph: {
         title: "All forms | FormAI",
         description:
-        "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+            "Create intelligent, responsive forms with our AI-powered builder. Customize fields, logic, and design effortlessly.",
         url: "/form-generator",
         siteName: "FormAI",
         images: ["/logo.png"],
@@ -26,7 +26,7 @@ export const metadata = {
         creator: "@Moamen-Yazouri",
         title: "Form Generator | FormAI",
         description:
-            "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+            "Create intelligent, responsive forms with our AI-powered builder. Customize fields, logic, and design effortlessly.",
         images: ["/logo.png"],
     },
     other: {
@@ -36,9 +36,9 @@ export const metadata = {
 };
 
 const page = () => {
-  return (
-    <FormGeneratorPage />
-  )
+    return (
+        <FormGeneratorPage />
+    )
 }
 
 export default page;

--- a/app/(main)/my-forms/[name]/page.tsx
+++ b/app/(main)/my-forms/[name]/page.tsx
@@ -4,7 +4,7 @@ import { getCreatorForms } from '../service/fetchData.service';
 export const metadata = {
     title: "My Forms | FormAI",
     description:
-        "Powerful admin dashboard to oversee form submissions, manage users, and control platform settings in one centralized interface.",
+        "Access and manage all your forms in one place. Edit, share, or analyze form performance with the Form AI Builder page.",
     keywords: [
         "creator forms",
         "admin forms",
@@ -16,7 +16,7 @@ export const metadata = {
     openGraph: {
         title: "My Forms | FormAI",
         description:
-        "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+        "View and manage all the forms you’ve created. Edit, duplicate, or track performance from one centralized page.",
         url: "/my-forms/[name]",
         siteName: "FormAI",
         images: ["/logo.png"],
@@ -28,7 +28,7 @@ export const metadata = {
         creator: "@Moamen-Yazouri",
         title: "My Forms | FormAI",
         description:
-            "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+            "View and manage all the forms you’ve created. Edit, duplicate, or track performance from one centralized page.",
         images: ["/logo.png"],
     },
     other: {

--- a/app/(main)/profile/[name]/page.tsx
+++ b/app/(main)/profile/[name]/page.tsx
@@ -2,7 +2,7 @@ import ProfilePage from "../components/profile-Page";
 export const metadata = {
     title: "Profile | FormAI",
     description:
-        "Powerful admin dashboard to oversee form submissions, manage users, and control platform settings in one centralized interface.",
+        "Manage your account settings. Edit your profile information and update your password securely with Form AI Builder.",
     keywords: [
         "profile",
         "account",
@@ -17,7 +17,7 @@ export const metadata = {
     openGraph: {
         title: "Profile | FormAI",
         description:
-        "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+        "Update your personal information and change your password securely. Manage your account settings with ease.",
         url: "/profile/[name]",
         siteName: "FormAI",
         images: ["/logo.png"],
@@ -29,7 +29,7 @@ export const metadata = {
         creator: "@Moamen-Yazouri",
         title: "Profile | FormAI",
         description:
-            "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+            "Update your personal information and change your password securely. Manage your account settings with ease.",        
         images: ["/logo.png"],
     },
     other: {

--- a/app/(main)/review-response/[id]/page.tsx
+++ b/app/(main)/review-response/[id]/page.tsx
@@ -6,7 +6,7 @@ import { handleAccess } from '@/lib/triggerCoventions';
 export const metadata = {
     title: "Review Response | FormAI",
     description:
-        "Powerful admin dashboard to oversee form submissions, manage users, and control platform settings in one centralized interface.",
+        "Review and analyze a specific response submitted to your form. Access detailed answers and insights with Form AI Builder.",
     keywords: [
         "review response",
         "view response",
@@ -19,7 +19,7 @@ export const metadata = {
     openGraph: {
         title: "Review Response | FormAI",
         description:
-        "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+        "Examine individual form submissions in detail. Review answers, assess input quality, and take action if needed.",
         url: "/review-response/[id]",
         siteName: "FormAI",
         images: ["/logo.png"],
@@ -31,7 +31,7 @@ export const metadata = {
         creator: "@Moamen-Yazouri",
         title: "Review Response | FormAI",
         description:
-            "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+            "Examine individual form submissions in detail. Review answers, assess input quality, and take action if needed.",
         images: ["/logo.png"],
     },
     other: {

--- a/app/(main)/user/[name]/dashboard/page.tsx
+++ b/app/(main)/user/[name]/dashboard/page.tsx
@@ -3,7 +3,7 @@ import fetchDataService from "./service/fetchData.service";
 export const metadata = {
     title: "User Dashboard | FormAI",
     description:
-        "Powerful admin dashboard to oversee form submissions, manage users, and control platform settings in one centralized interface.",
+        "Your personal dashboard to manage form submissions, update profile settings, and monitor your activity across Form AI Builder.",
     keywords: [
         "user management",
         "user responses",
@@ -16,7 +16,7 @@ export const metadata = {
     openGraph: {
         title: "User Dashboard | FormAI",
         description:
-        "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+            "Access your dashboard to view submitted forms, manage account settings, and track your activity in one place.",
         url: "/user/[name]",
         siteName: "FormAI",
         images: ["/logo.png"],
@@ -28,7 +28,7 @@ export const metadata = {
         creator: "@Moamen-Yazouri",
         title: "User Dashboard | FormAI",
         description:
-            "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+            "Access your dashboard to view submitted forms, manage account settings, and track your activity in one place.",
         images: ["/logo.png"],
     },
     other: {

--- a/app/(main)/user/[name]/responses-details/page.tsx
+++ b/app/(main)/user/[name]/responses-details/page.tsx
@@ -3,7 +3,7 @@ import fetchDataService from '../dashboard/service/fetchData.service';
 export const metadata = {
     title: "Responses Details | FormAI",
     description:
-        "Powerful admin dashboard to oversee form submissions, manage users, and control platform settings in one centralized interface.",
+        "Access all the responses you’ve submitted through Form AI Builder. Review your answers and track form participation history easily.",
     keywords: [
         "responses table",
         "view all responses",
@@ -16,7 +16,7 @@ export const metadata = {
     openGraph: {
         title: "Responses Details | FormAI",
         description:
-        "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+        "View and manage the responses you’ve submitted to forms. Keep track of your activity and submissions in one place.",
         url: "/user/[name]/responses-details",
         siteName: "FormAI",
         images: ["/logo.png"],
@@ -28,7 +28,7 @@ export const metadata = {
         creator: "@Moamen-Yazouri",
         title: "Responses Details | FormAI",
         description:
-            "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+            "View and manage the responses you’ve submitted to forms. Keep track of your activity and submissions in one place.",
         images: ["/logo.png"],
     },
     other: {

--- a/app/(main)/view-form/[id]/page.tsx
+++ b/app/(main)/view-form/[id]/page.tsx
@@ -4,7 +4,7 @@ import { getAccessRights } from '../service/accessRight.service';
 export const metadata = {
     title: "View Form | FormAI",
     description:
-        "Powerful admin dashboard to oversee form submissions, manage users, and control platform settings in one centralized interface.",
+        "Review the layout, logic, and content of your form as a creator or admin. Ensure everything is correct before sharing or analyzing responses.",
     keywords: [
         "See Form",
         "view form",
@@ -17,7 +17,7 @@ export const metadata = {
     openGraph: {
         title: "View Forms | FormAI",
         description:
-        "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+            "Preview and inspect the structure of your form. Ensure accuracy, logic, and design before publishing or reviewing responses.",
         url: "/view-forms/[id]",
         siteName: "FormAI",
         images: ["/logo.png"],
@@ -29,7 +29,7 @@ export const metadata = {
         creator: "@Moamen-Yazouri",
         title: "View Forms | FormAI",
         description:
-            "Access the admin dashboard to manage users, forms, and platform activity. Monitor submissions, enforce policies, and maintain control over your application's operations.",
+            "Preview and inspect the structure of your form. Ensure accuracy, logic, and design before publishing or reviewing responses.",
         images: ["/logo.png"],
     },
     other: {


### PR DESCRIPTION

Improve page metadata descriptions to accurately reflect each page's purpose and functionality, replacing generic admin dashboard text with page-specific descriptions that better describe what users can do on each page.