### PR TITLE
build: relax TypeScript and ESLint strict type checking rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,8 @@ const eslintConfig = [
     rules: {
       "react/no-unescaped-entities": "off",
       "@typescript-eslint/no-empty-interface": "off",
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-empty-object-type": "off",
     },
   },
 ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
-    "noImplicitAny": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
Remove `noImplicitAny` from tsconfig and disable additional ESLint type checking rules to allow more flexible type usage in the codebase. This change provides developers with more flexibility when working with types while maintaining other strict checks.