### PR TITLE
chore: update metadataBase URL to form-ai-gold.vercel.app

### DIFF
--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -12,7 +12,7 @@ export const metadata = {
         "Credentials",
         "authentication",
     ],
-    metadataBase: new URL(new URL("https://formai.vercel.app"),),
+    metadataBase: new URL(new URL("https://form-ai-gold.vercel.app"),),
     openGraph: {
         title: "Sign-In | FormAI",
         description:

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -10,7 +10,7 @@ export const metadata = {
         "create account",
         "new account",
     ],
-    metadataBase: new URL(new URL("https://formai.vercel.app"),),
+    metadataBase: new URL(new URL("https://form-ai-gold.vercel.app"),),
     openGraph: {
         title: "Sign-Up | FormAI",
         description:

--- a/app/(main)/admin/all-forms/page.tsx
+++ b/app/(main)/admin/all-forms/page.tsx
@@ -15,7 +15,7 @@ export const metadata = {
         "admin tools",
     ],
 
-    metadataBase: new URL(new URL("https://formai.vercel.app"),),
+    metadataBase: new URL(new URL("https://form-ai-gold.vercel.app"),),
     openGraph: {
         title: "All forms | FormAI",
         description:

--- a/app/(main)/admin/all-users/page.tsx
+++ b/app/(main)/admin/all-users/page.tsx
@@ -13,7 +13,7 @@ export const metadata = {
         "platform oversight",
         "admin tools",
     ],
-    metadataBase: new URL(new URL("https://formai.vercel.app"),),
+    metadataBase: new URL(new URL("https://form-ai-gold.vercel.app"),),
     openGraph: {
         title: "All forms | FormAI",
         description:

--- a/app/(main)/admin/creator-forms/[name]/page.tsx
+++ b/app/(main)/admin/creator-forms/[name]/page.tsx
@@ -14,7 +14,7 @@ export const metadata = {
         "admin tools",
         "creator forms"
     ],
-    metadataBase: new URL(new URL("https://formai.vercel.app"),),
+    metadataBase: new URL(new URL("https://form-ai-gold.vercel.app"),),
     openGraph: {
         title: "Creator Forms | FormAI",
         description:

--- a/app/(main)/admin/dashboard/page.tsx
+++ b/app/(main)/admin/dashboard/page.tsx
@@ -12,7 +12,7 @@ export const metadata = {
         "platform oversight",
         "admin tools",
     ],
-    metadataBase: new URL(new URL("https://formai.vercel.app"),),
+    metadataBase: new URL(new URL("https://form-ai-gold.vercel.app"),),
     openGraph: {
         title: "All forms | FormAI",
         description:

--- a/app/(main)/answer-form/[id]/page.tsx
+++ b/app/(main)/answer-form/[id]/page.tsx
@@ -8,7 +8,7 @@ export const metadata = {
     keywords: [
         "Answer Form",
     ],
-    metadataBase: new URL(new URL("https://formai.vercel.app"),),
+    metadataBase: new URL(new URL("https://form-ai-gold.vercel.app"),),
     openGraph: {
         title: "Answer Form | FormAI",
         description:

--- a/app/(main)/available-forms/[name]/page.tsx
+++ b/app/(main)/available-forms/[name]/page.tsx
@@ -11,7 +11,7 @@ export const metadata = {
         "available forms",
         "Your forms"
     ],
-    metadataBase: new URL(new URL("https://formai.vercel.app"),),
+    metadataBase: new URL(new URL("https://form-ai-gold.vercel.app"),),
     openGraph: {
         title: "Available Forms | FormAI",
         description:

--- a/app/(main)/creator/[name]/all-responses/page.tsx
+++ b/app/(main)/creator/[name]/all-responses/page.tsx
@@ -11,7 +11,7 @@ export const metadata = {
         "responses moderation",
         "creator tools",
     ],
-    metadataBase: new URL(new URL("https://formai.vercel.app"),),
+    metadataBase: new URL(new URL("https://form-ai-gold.vercel.app"),),
     openGraph: {
         title: "All forms | FormAI",
         description:

--- a/app/(main)/creator/[name]/dashboard/page.tsx
+++ b/app/(main)/creator/[name]/dashboard/page.tsx
@@ -12,7 +12,7 @@ export const metadata = {
         "responses moderation",
         "creator tools",
     ],
-    metadataBase: new URL(new URL("https://formai.vercel.app"),),
+    metadataBase: new URL(new URL("https://form-ai-gold.vercel.app"),),
     openGraph: {
         title: "Creator Dashboard | FormAI",
         description:

--- a/app/(main)/form-answers/[name]/[id]/page.tsx
+++ b/app/(main)/form-answers/[name]/[id]/page.tsx
@@ -15,7 +15,7 @@ export const metadata = {
         "admin tools",
         "creator tools",
     ],
-    metadataBase: new URL(new URL("https://formai.vercel.app"),),
+    metadataBase: new URL(new URL("https://form-ai-gold.vercel.app"),),
     openGraph: {
         title: "Form Answers | FormAI",
         description:

--- a/app/(main)/form-generator/page.tsx
+++ b/app/(main)/form-generator/page.tsx
@@ -9,7 +9,7 @@ export const metadata = {
         "create forms",
         "AI generator",
     ],
-    metadataBase: new URL(new URL("https://formai.vercel.app"),),
+    metadataBase: new URL(new URL("https://form-ai-gold.vercel.app"),),
     openGraph: {
         title: "All forms | FormAI",
         description:

--- a/app/(main)/my-forms/[name]/page.tsx
+++ b/app/(main)/my-forms/[name]/page.tsx
@@ -11,7 +11,7 @@ export const metadata = {
         "my forms",
         "created forms",
     ],
-    metadataBase: new URL(new URL("https://formai.vercel.app"),),
+    metadataBase: new URL(new URL("https://form-ai-gold.vercel.app"),),
     openGraph: {
         title: "My Forms | FormAI",
         description:

--- a/app/(main)/profile/[name]/page.tsx
+++ b/app/(main)/profile/[name]/page.tsx
@@ -12,7 +12,7 @@ export const metadata = {
         "change email",
         "change role"
     ],
-    metadataBase: new URL(new URL("https://formai.vercel.app"),),
+    metadataBase: new URL(new URL("https://form-ai-gold.vercel.app"),),
     openGraph: {
         title: "Profile | FormAI",
         description:

--- a/app/(main)/profile/components/profile-header.tsx
+++ b/app/(main)/profile/components/profile-header.tsx
@@ -1,16 +1,14 @@
 "use client"
 
-import type React from "react"
-import { use, useState } from "react"
-import { Avatar, AvatarFallback } from "@/components/ui/avatar"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
-import { Camera, Check, X } from "lucide-react"
-import { AuthContext } from "@/providers/auth/authProvider"
-import FullPageLoader from "./profileLoader"
+import type React from "react";
+import { useContext} from "react";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Card, CardContent } from "@/components/ui/card";
+import { AuthContext } from "@/providers/auth/authProvider";
+import FullPageLoader from "./profileLoader";
 
 export default function ProfileHeader() {
-    const { user, isLoading } = use(AuthContext)
+    const { user, isLoading } = useContext(AuthContext)
     
 
     if (isLoading) return <FullPageLoader />

--- a/app/(main)/review-response/[id]/page.tsx
+++ b/app/(main)/review-response/[id]/page.tsx
@@ -15,7 +15,7 @@ export const metadata = {
         "contact",
     ],
     viewport: "width=device-width, initial-scale=1",
-    metadataBase: new URL(new URL("https://formai.vercel.app"),),
+    metadataBase: new URL(new URL("https://form-ai-gold.vercel.app"),),
     openGraph: {
         title: "Review Response | FormAI",
         description:

--- a/app/(main)/user/[name]/dashboard/page.tsx
+++ b/app/(main)/user/[name]/dashboard/page.tsx
@@ -12,7 +12,7 @@ export const metadata = {
         "user activity",
         "user tools",
     ],
-    metadataBase: new URL(new URL("https://formai.vercel.app"),),
+    metadataBase: new URL(new URL("https://form-ai-gold.vercel.app"),),
     openGraph: {
         title: "User Dashboard | FormAI",
         description:

--- a/app/(main)/user/[name]/responses-details/page.tsx
+++ b/app/(main)/user/[name]/responses-details/page.tsx
@@ -11,7 +11,7 @@ export const metadata = {
         "user responses",
         "user tools",
     ],
-    metadataBase: new URL(new URL("https://formai.vercel.app"),),
+    metadataBase: new URL(new URL("https://form-ai-gold.vercel.app"),),
     openGraph: {
         title: "Responses Details | FormAI",
         description:

--- a/app/(main)/view-form/[id]/page.tsx
+++ b/app/(main)/view-form/[id]/page.tsx
@@ -12,7 +12,7 @@ export const metadata = {
         "creator tools",
         "admin tools",
     ],
-    metadataBase: new URL(new URL("https://formai.vercel.app"),),
+    metadataBase: new URL(new URL("https://form-ai-gold.vercel.app"),),
     openGraph: {
         title: "View Forms | FormAI",
         description:

--- a/components/app-sidebar/components/login-info.tsx
+++ b/components/app-sidebar/components/login-info.tsx
@@ -66,10 +66,13 @@ const LoginInfo = () => {
           size="sm"
           className="w-full mt-4 text-red-300 hover:text-red-200 hover:bg-red-900/30 border border-red-700/30 hover:border-red-600/50 transition-all duration-200"
         >
-          <LogOut className="h-4 w-4 mr-2" />
+          
             {
               loggingOut ? (<Loader />) : (
-                <span>Log out</span>
+                <>
+                  <LogOut className="h-4 w-4 mr-2" />
+                  <span>Log out</span>
+                </>
               )
             }
         </Button>


### PR DESCRIPTION
Update the metadataBase URL across all pages from formai.vercel.app to form-ai-gold.vercel.app to reflect the new deployment domain.