### PR TITLE
fix: enable required validation for checkbox fields

### DIFF
--- a/lib/createTheValidationSchema.ts
+++ b/lib/createTheValidationSchema.ts
@@ -24,9 +24,9 @@ export const generateValidationSchema = (formData: IFormField[]) => {
         if(field.type === "checkbox") {
             let validator = yup.boolean();
 
-            // if (field.required) {
-            //     validator = validator.required("This field is required");
-            // }
+            if (field.required) {
+                validator = validator.required("This field is required");
+            }
 
             acc[field.fieldId.toLowerCase()] = validator;
             return acc;


### PR DESCRIPTION
Uncomment and activate the required validation for checkbox fields in the validation schema generator to ensure proper form validation when checkboxes are marked as required.