### PR TITLE
fix(response): correct user response validation logic

### DIFF
--- a/module/services/response.service.ts
+++ b/module/services/response.service.ts
@@ -15,15 +15,15 @@ class ResponseService {
         }
         const validation: {[key: string]: any} = {};
         response.answers.forEach(answer => {
-            validation[String(answer.fieldId).toLowerCase()] = answer.answer;
+            validation[String(answer.fieldId)] = answer.answer;
         })
-        console.log(generateValidationSchema(form.fields));
         const isValid = await generateValidationSchema(form.fields).isValid(validation);
 
         if(!isValid) {
             throw new Error("Invalid response");
         }
-        const responded = form.answeredBy.some(res => res === response.userId);
+        const responded = form.answeredBy.some(res => String(res) === String(response.userId));
+        console.log(validation);
         if(!responded) {
             let idToSend = String(response.userId);
             if(response.anonymous) {


### PR DESCRIPTION
Fix the comparison logic for checking if a user has already responded by ensuring proper string conversion. This prevents false negatives when comparing user IDs of different types (number vs string). Also remove unnecessary console log of schema generation.