### PR TITLE
fix(forms-table): change summary display threshold from 0 to 4 items

### DIFF
--- a/components/forms-table/formsTable.tsx
+++ b/components/forms-table/formsTable.tsx
@@ -208,7 +208,7 @@ const FormsTable = (props: IProps) => {
             </TableBody>
         </Table>
         {
-            isSummary && forms.length > 0  &&(
+            isSummary && forms.length > 4  && (
                 <div className="flex justify-center p-4">
                     <Button
                     variant="outline"

--- a/components/responses-table/responsesTable.tsx
+++ b/components/responses-table/responsesTable.tsx
@@ -168,7 +168,7 @@ const ResponsesTable = ({ responses, isSummary }: IProps) => {
             </TableBody>
         </Table>
 
-        {isSummary && (
+        {isSummary && responses.length > 5 && (
             <div className="flex justify-center p-4">
             <Link href={`/${user.role}/${user.name}/all-responses`}>
                 <Button


### PR DESCRIPTION
fix(responses-table): add threshold of 5 items for summary display

The changes ensure summary sections only appear when there are enough items to warrant them, preventing unnecessary UI elements from showing when there are too few items. The forms table threshold was increased from 0 to 4, while the responses table now requires at least 5 items to show the summary.