### PR TITLE
fix(login-info): delay logout and redirect to prevent race condition

### DIFF
--- a/components/app-sidebar/components/login-info.tsx
+++ b/components/app-sidebar/components/login-info.tsx
@@ -39,9 +39,13 @@ const LoginInfo = () => {
       toast.error("Something went wrong")
     }
     finally {
-      setLoggingOut(false)
+      setTimeout(() => {
+        setLoggingOut(false)
+      }, 2000);
     }
-    router.push("/sign-in");
+    setTimeout(() => {
+      router.push("/sign-in");
+    }, 1000);
   }
 
   return (


### PR DESCRIPTION
Add setTimeout to logout state update and redirect to ensure UI properly reflects logout state before redirecting. The 1s delay for redirect and 2s delay for state update prevent potential race conditions where the UI might not show the logout state before navigation occurs.