### PR TITLE
fix: redirect to sign-in immediately after logout

### DIFF
--- a/components/app-sidebar/components/login-info.tsx
+++ b/components/app-sidebar/components/login-info.tsx
@@ -27,13 +27,14 @@ const LoginInfo = () => {
   const handleLogout = async () => {
     setLoggingOut(true);
     try{
-      await Promise.all([
-        fetch("/api/auth/logout", {
+      await fetch("/api/auth/logout", {
           method: "POST",
           credentials: "include",
         }),
-        revalidateUser(),
-      ]);
+
+      revalidateUser();
+
+      router.push("/sign-in");
     }
     catch {
       toast.error("Something went wrong")
@@ -43,9 +44,7 @@ const LoginInfo = () => {
         setLoggingOut(false)
       }, 2000);
     }
-    setTimeout(() => {
-      router.push("/sign-in");
-    }, 1000);
+    
   }
 
   return (


### PR DESCRIPTION
Previously, there was a 1-second delay before redirecting to the sign-in page after logout. This delay was unnecessary and could cause confusion for users. The redirect is now performed immediately after successful logout operations.