### PR TITLE
refactor(layout): remove scroll container from root layout and move to main layout

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -2,6 +2,7 @@ import type React from "react"
 import "../globals.css"
 import { SidebarProvider } from "@/components/ui/sidebar"
 import AppSidebar from "@/components/app-sidebar/appSidebar"
+import { ScrollableContainer } from "@/components/scroll-container/scroll-container"
 
 
 export default function RootLayout({
@@ -13,7 +14,9 @@ export default function RootLayout({
 
         <SidebarProvider className="w-full">
           <AppSidebar />
+          <ScrollableContainer maxHeight="100vh" className="w-full">
             {children}
+          </ScrollableContainer>
         </SidebarProvider>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { Toaster } from "sonner";
 import { AuthProvider } from "@/providers/auth/authProvider";
-import { ScrollableContainer } from "@/components/scroll-container/scroll-container";
+
 
 
 
@@ -23,9 +23,7 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <AuthProvider>
-          <ScrollableContainer maxHeight="100vh">
             {children}
-          </ScrollableContainer>
         </AuthProvider>
         
         <Toaster richColors />

--- a/components/scroll-container/scroll-container.tsx
+++ b/components/scroll-container/scroll-container.tsx
@@ -14,7 +14,7 @@ const ScrollableContainer = React.forwardRef<HTMLDivElement, ScrollableContainer
         return (
         <div
             ref={ref}
-            className={cn("overflow-y-auto", hideScrollbar ? "scrollbar-hide" : "custom-scrollbar pr-2", isMobile && "mt-14",className)}
+            className={cn("overflow-y-auto", hideScrollbar ? "scrollbar-hide" : "custom-scrollbar pr-2", className)}
             style={{ maxHeight }}
             {...props}
         >


### PR DESCRIPTION


The ScrollableContainer component was removed from the root layout and added to the main layout instead. This change improves the layout structure by:
- Avoiding unnecessary scroll container nesting
- Making the scroll behavior more specific to the main content area
- Removing redundant mobile margin class from scroll container